### PR TITLE
DB: Add skeleton DB connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore database env file.
+/database/.env

--- a/database/database.go
+++ b/database/database.go
@@ -2,15 +2,62 @@ package database
 
 import (
 	"database/sql"
+	"log"
 	"os"
 
+	"github.com/joho/godotenv"
 	_ "github.com/lib/pq"
 )
 
-func db() {
-	DATABASE_URL := "postgres://ddbrflhccgsbnv:9dea2c78cfd420c6af3f51e1bac56c9a15ed73dc73ad1b50172c5e973b613e37@ec2-44-206-137-96.compute-1.amazonaws.com:5432/devchlvlplpfpu"
-	db, err := sql.Open("postgres", os.Getenv(DATABASE_URL))
+// Loads Database URI from .env file
+func loadDbUri() string {
+	err := godotenv.Load("database/.env")
+
 	if err != nil {
 		panic(err)
 	}
+
+	log.Printf("Env value: %s", os.Getenv("DATABASE_URI"))
+
+	return os.Getenv("DATABASE_URI")
+}
+
+func GetDb() *sql.DB {
+	db, err := sql.Open("postgres", loadDbUri())
+	if err != nil {
+		panic(err)
+	}
+
+	return db
+}
+
+type Module struct {
+	Id   string
+	Name string
+	Desc string
+}
+
+func GetModules(db *sql.DB) []Module {
+	rows, err := db.Query("SELECT * FROM Modules")
+	if err != nil {
+		panic(err)
+	}
+	defer rows.Close()
+
+	var modules []Module
+
+	for rows.Next() {
+		var mod Module
+		err := rows.Scan(&mod.Id, &mod.Name, &mod.Desc)
+		if err != nil {
+			panic(err)
+		}
+		modules = append(modules, mod)
+	}
+
+	if rows.Err() != nil {
+		panic(err)
+	}
+
+	return modules
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-playground/validator/v10 v10.11.1 // indirect
 	github.com/goccy/go-json v0.9.11 // indirect
+	github.com/joho/godotenv v1.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/lib/pq v1.10.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MG
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
+github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/main.go
+++ b/main.go
@@ -1,17 +1,34 @@
 package main
 
 import (
+	"database/sql"
+	"example/web-service-gin/database"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
 
+// Still a bit messy, sql.DB should not be exposed
+// outside of database pkg. However, sufficient for now.
+func getModules(db *sql.DB) func(c *gin.Context) {
+	return func(c *gin.Context) {
+		modules := database.GetModules(db)
+		c.JSON(http.StatusOK, modules)
+	}
+}
+
 func main() {
 	r := gin.Default()
+
+	db := database.GetDb()
+
 	r.GET("/ping", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
 			"message": "pong",
 		})
 	})
+
+	r.GET("/module", getModules(db))
+
 	r.Run() // listen and serve on 0.0.0.0:8080 (for windows "localhost:8080")
 }


### PR DESCRIPTION
A skeleton DB package to connect from the postgre database. A simple "/module" API endpoint added for proof-of-concept.
Note that the database URI must be stored in `database/.env` with the name `DATABASE_URI`.