### PR TITLE
Change GET module request

### DIFF
--- a/database/module.go
+++ b/database/module.go
@@ -15,8 +15,15 @@ type Module struct {
 	SubscriberCount int
 }
 
-func GetModules(db *sql.DB) []Module {
-	rows, err := db.Query("SELECT * FROM Modules LIMIT 10")
+func GetModules(db *sql.DB, keyword string, page int) []Module {
+	sql_statement := `
+	SELECT * FROM MODULES
+	WHERE id LIKE '%' || UPPER($1) || '%'
+	OFFSET $2
+	LIMIT 10
+	`
+
+	rows, err := db.Query(sql_statement, keyword, 10*(page-1))
 	if err != nil {
 		panic(err)
 	}

--- a/router/module.go
+++ b/router/module.go
@@ -12,7 +12,22 @@ import (
 // outside of database pkg. However, sufficient for now.
 func GetModules(db *sql.DB) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		modules := database.GetModules(db)
+		var SearchQuery struct {
+			Keyword string `json:"keyword"`
+			Page    int    `json:"page"`
+		}
+
+		err := c.ShouldBindJSON(&SearchQuery)
+		if err != nil {
+			panic(err)
+		}
+
+		// If page is not specified, default is 1
+		if SearchQuery.Page == 0 {
+			SearchQuery.Page = 1
+		}
+
+		modules := database.GetModules(db, SearchQuery.Keyword, SearchQuery.Page)
 		c.JSON(http.StatusOK, gin.H{
 			"module_list": modules,
 		})


### PR DESCRIPTION
Add two optional parameters (keyword and page) to GET /module. If not specified, the default keyword and page is empty string and 1 respectively. 

For example, 

- GET module request with parameters { keyword: "CS2", page: 1 } will give the first 10 mods with keyword "CS2" (eg. CS2030, CS2030S, etc.)
- GET module request with parameters { keyword: "CS2", page: 2 } will give the next 10 mods with keyword "CS2"

