### PR TITLE
Handles JSON Parsing Error

### DIFF
--- a/router/comment.go
+++ b/router/comment.go
@@ -24,7 +24,11 @@ func GetCommentById(db *sql.DB) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		id, err := strconv.Atoi(c.Param("id"))
 		if err != nil {
-			panic(err)
+			c.JSON(http.StatusBadRequest, gin.H{
+				"status": "failure",
+				"cause": "Comment id is malformed",
+			})
+			return
 		}
 		comment := database.GetCommentById(db, id)
 
@@ -42,13 +46,21 @@ func DeleteCommentById(db *sql.DB) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		id, convErr := strconv.Atoi(c.Param("id"))
 		if convErr != nil {
-			panic(convErr)
+			c.JSON(http.StatusBadRequest, gin.H{
+				"status": "failure",
+				"cause": "Comment id is malformed",
+			})
+			return
 		}
 
 		var requestBody DeleteCommentBody
 		bodyErr := c.BindJSON(&requestBody)
 		if bodyErr != nil {
-			panic(bodyErr)
+			c.JSON(http.StatusBadRequest, gin.H{
+				"status": "failure",
+				"cause": "Request body is malformed",
+			})
+			return
 		}
 
 		status := database.DeleteCommentById(db, id, requestBody.UserId,
@@ -67,13 +79,20 @@ func UpdateCommentById(db *sql.DB) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		id, convErr := strconv.Atoi(c.Param("id"))
 		if convErr != nil {
-			panic(convErr)
+			c.JSON(http.StatusBadRequest, gin.H{
+				"status": "failure",
+				"cause": "Comment id is malformed",
+			})
+			return
 		}
 
 		var requestBody UpdateCommentBody
 		bodyErr := c.BindJSON(&requestBody)
 		if bodyErr != nil {
-			panic(bodyErr)
+			c.JSON(http.StatusBadRequest, gin.H{
+				"status": "failure",
+				"cause": "Request body is malformed",
+			})
 		}
 
 		status := database.UpdateCommentById(db, id, requestBody.Content,

--- a/router/likes.go
+++ b/router/likes.go
@@ -17,7 +17,7 @@ func GetLikeThread(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err.Error(),
 			})
-			panic(err)
+			return
 		}
 
 		userid, err2 := strconv.Atoi(c.Param("userid"))
@@ -26,7 +26,7 @@ func GetLikeThread(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err2.Error(),
 			})
-			panic(err2)
+			return
 		}
 
 		state, err3 := database.GetLikeThread(db, threadid, userid)
@@ -35,7 +35,7 @@ func GetLikeThread(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err3.Error(),
 			})
-			panic(err3)
+			return
 		}
 		c.JSON(http.StatusOK, gin.H{
 			"state": state,
@@ -51,7 +51,7 @@ func SetLikeThread(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err.Error(),
 			})
-			panic(err)
+			return
 		}
 
 		userid, err2 := strconv.Atoi(c.Param("userid"))
@@ -60,7 +60,7 @@ func SetLikeThread(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err2.Error(),
 			})
-			panic(err2)
+			return
 		}
 
 		state, err3 := strconv.Atoi(c.Param("state"))
@@ -69,7 +69,7 @@ func SetLikeThread(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err3.Error(),
 			})
-			panic(err3)
+			return
 		}
 
 		if state != 0 && state != 1 && state != -1 {
@@ -86,7 +86,7 @@ func SetLikeThread(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err4.Error(),
 			})
-			panic(err4)
+			return
 		}
 
 		c.JSON(http.StatusOK, gin.H{
@@ -103,7 +103,7 @@ func GetLikeComment(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err.Error(),
 			})
-			panic(err)
+			return
 		}
 
 		userid, err2 := strconv.Atoi(c.Param("userid"))
@@ -112,7 +112,7 @@ func GetLikeComment(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err2.Error(),
 			})
-			panic(err2)
+			return
 		}
 
 		state, err3 := database.GetLikeComment(db, commentid, userid)
@@ -121,7 +121,7 @@ func GetLikeComment(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err3.Error(),
 			})
-			panic(err3)
+			return
 		}
 		c.JSON(http.StatusOK, gin.H{
 			"state": state,
@@ -137,7 +137,7 @@ func SetLikeComment(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err.Error(),
 			})
-			panic(err)
+			return
 		}
 
 		userid, err2 := strconv.Atoi(c.Param("userid"))
@@ -146,7 +146,7 @@ func SetLikeComment(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err2.Error(),
 			})
-			panic(err2)
+			return
 		}
 
 		state, err3 := strconv.Atoi(c.Param("state"))
@@ -155,7 +155,7 @@ func SetLikeComment(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err3.Error(),
 			})
-			panic(err3)
+			return
 		}
 
 		if state != 0 && state != 1 && state != -1 {
@@ -172,7 +172,7 @@ func SetLikeComment(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err4.Error(),
 			})
-			panic(err4)
+			return
 		}
 
 		c.JSON(http.StatusOK, gin.H{

--- a/router/me.go
+++ b/router/me.go
@@ -11,12 +11,16 @@ import (
 func GetPersonalInfo(db *sql.DB) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		var User struct {
-			UserId int `json:"userid"`
+			UserId int `json:"userid" binding:"required"`
 		}
 
 		err := c.ShouldBindJSON(&User)
 		if err != nil {
-			panic(err)
+			c.JSON(http.StatusBadRequest, gin.H{
+				"status": "failure",
+				"cause": "A field is malformed or non-existent",
+			})
+			return
 		}
 
 		info, err2 := database.GetPersonalInfo(db, User.UserId)
@@ -25,7 +29,7 @@ func GetPersonalInfo(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err2.Error(),
 			})
-			panic(err2)
+			return
 		}
 		c.JSON(http.StatusOK, info)
 

--- a/router/module.go
+++ b/router/module.go
@@ -19,7 +19,11 @@ func GetModules(db *sql.DB) func(c *gin.Context) {
 
 		err := c.ShouldBindJSON(&SearchQuery)
 		if err != nil {
-			panic(err)
+			c.JSON(http.StatusBadRequest, gin.H{
+				"status": "failure",
+				"cause": "Request body is malformed",
+			})
+			return
 		}
 
 		// If page is not specified, default is 1
@@ -49,14 +53,18 @@ func PostThread(db *sql.DB) func(c *gin.Context) {
 		moduleid := c.Param("moduleid")
 
 		var Module struct {
-			AuthorId int    `json:"authorid"`
-			Content  string `json:"content"`
-			Title    string `json:"title"`
-			Tags	 []int	`json:"tags"`
+			AuthorId int    `json:"authorid" binding:"required"`
+			Content  string `json:"content" binding:"required"`
+			Title    string `json:"title" binding:"required"`
+			Tags	 []int	`json:"tags" binding:"required"`
 		}
 		err := c.ShouldBindJSON(&Module)
 		if err != nil {
-			panic(err)
+			c.JSON(http.StatusBadRequest, gin.H{
+				"status": "failure",
+				"cause": "Request body is malformed",
+			})
+			return
 		}
 
 		err2 := database.PostThread(db, Module.AuthorId, Module.Content, Module.Title, Module.Tags, moduleid)
@@ -65,7 +73,7 @@ func PostThread(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err2.Error(),
 			})
-			panic(err2)
+			return
 		}
 
 		//err := database.EditThreadById(db, threadid)

--- a/router/subscribes.go
+++ b/router/subscribes.go
@@ -30,7 +30,7 @@ func DoesSubscribe(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err.Error(),
 			})
-			panic(err)
+			return
 		}
 
 		res, err2 := database.DoesSubscribe(db, moduleid, userid)
@@ -39,7 +39,7 @@ func DoesSubscribe(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err2.Error(),
 			})
-			panic(err2)
+			return
 		}
 		c.JSON(http.StatusOK, gin.H{
 			"subscribed": res,
@@ -56,7 +56,7 @@ func Subscribe(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err.Error(),
 			})
-			panic(err)
+			return
 		}
 
 		err2 := database.Subscribe(db, moduleid, userid)
@@ -65,7 +65,7 @@ func Subscribe(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err2.Error(),
 			})
-			panic(err2)
+			return
 		}
 
 		c.JSON(http.StatusOK, gin.H{
@@ -92,7 +92,7 @@ func Unsubscribe(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err2.Error(),
 			})
-			panic(err2)
+			return
 		}
 
 		c.JSON(http.StatusOK, gin.H{

--- a/router/thread.go
+++ b/router/thread.go
@@ -25,7 +25,11 @@ func EditThreadById(db *sql.DB) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		threadid, err := strconv.Atoi(c.Param("threadid"))
 		if err != nil {
-			panic(err)
+			c.JSON(http.StatusBadRequest, gin.H{
+				"status": "failure",
+				"cause": "Thread id is malformed",
+			})
+			return
 		}
 
 		var EditedThread struct {
@@ -35,7 +39,11 @@ func EditThreadById(db *sql.DB) func(c *gin.Context) {
 		}
 		err = c.ShouldBindJSON(&EditedThread)
 		if err != nil {
-			panic(err)
+			c.JSON(http.StatusBadRequest, gin.H{
+				"status": "failure",
+				"cause": "Request body is malformed",
+			})
+			return
 		}
 
 		err2 := database.EditThreadById(db, EditedThread.Title, EditedThread.Content, EditedThread.Tags, threadid)
@@ -44,7 +52,7 @@ func EditThreadById(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err2.Error(),
 			})
-			panic(err2)
+			return
 		}
 
 		//err := database.EditThreadById(db, threadid)
@@ -58,17 +66,25 @@ func PostComment(db *sql.DB) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		threadid, err := strconv.Atoi(c.Param("threadid"))
 		if err != nil {
-			panic(err)
+			c.JSON(http.StatusBadRequest, gin.H{
+				"status": "failure",
+				"cause": "Thread id is malformed",
+			})
+			return
 		}
 
 		var Comment struct {
-			AuthorId int    `json:"authorid"`
-			Content  string `json:"content"`
-			ParentId int    `json:"parentid"`
+			AuthorId int    `json:"authorid" binding:"required"`
+			Content  string `json:"content" binding:"required"`
+			ParentId int    `json:"parentid" binding:"required"`
 		}
 		err = c.ShouldBindJSON(&Comment)
 		if err != nil {
-			panic(err)
+			c.JSON(http.StatusBadRequest, gin.H{
+				"status": "failure",
+				"cause": "Request body is malformed",
+			})
+			return
 		}
 
 		err2 := database.PostComment(db, Comment.AuthorId, Comment.Content, Comment.ParentId, threadid)
@@ -77,7 +93,7 @@ func PostComment(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err2.Error(),
 			})
-			panic(err2)
+			return
 		}
 
 		//err := database.EditThreadById(db, threadid)

--- a/router/user.go
+++ b/router/user.go
@@ -17,13 +17,17 @@ func isEmailValid(e string) bool {
 func SignUp(db *sql.DB) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		var User struct {
-			Email    string `json:"email"`
-			Username string `json:"username"`
-			Password string `json:"password"`
+			Email    string `json:"email" binding:"required"`
+			Username string `json:"username" binding:"required"`
+			Password string `json:"password" binding:"required"`
 		}
 		err := c.ShouldBindJSON(&User)
 		if err != nil {
-			panic(err)
+			c.JSON(http.StatusBadRequest, gin.H{
+				"status": "failure",
+				"cause": "Request body is malformed",
+			})
+			return
 		}
 
 		is_alphanumeric := regexp.MustCompile(`^[a-zA-Z0-9]*$`).MatchString(User.Username)
@@ -51,10 +55,8 @@ func SignUp(db *sql.DB) func(c *gin.Context) {
 				"cause":  err2.Error(),
 			})
 			return
-			//panic(err2)
 		}
 
-		//err := database.EditThreadById(db, threadid)
 		c.JSON(http.StatusOK, gin.H{
 			"status": "success",
 		})
@@ -64,12 +66,16 @@ func SignUp(db *sql.DB) func(c *gin.Context) {
 func LogIn(db *sql.DB) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		var User struct {
-			NameOrEmail string `json:"username"`
-			Password string `json:"password"`
+			NameOrEmail string `json:"username" binding:"required"`
+			Password string `json:"password" binding:"required"`
 		}
 		err := c.ShouldBindJSON(&User)
 		if err != nil {
-			panic(err)
+			c.JSON(http.StatusBadRequest, gin.H{
+				"status": "failure",
+				"cause": "Request body is malformed",
+			})
+			return
 		}
 
 		success, token, err2 := database.LogIn(db, User.NameOrEmail, User.Password)
@@ -79,7 +85,7 @@ func LogIn(db *sql.DB) func(c *gin.Context) {
 				"status": "failure",
 				"cause":  err2.Error(),
 			})
-			panic(err2)
+			return
 		}
 
 		var status string
@@ -89,7 +95,7 @@ func LogIn(db *sql.DB) func(c *gin.Context) {
 			status = "failure"
 			token = ""
 		}
-		//err := database.EditThreadById(db, threadid)
+		
 		c.JSON(http.StatusOK, gin.H{
 			"status": status,
 			"token":  token,


### PR DESCRIPTION
Resolves #25.

On a malformed JSON body request, a 400 Bad Request is sent along with a generic "Request body is malformed". Not ideal, but still better than `panic`-ing on any error.

In addition, added error handling for cases where string conversion to integer fails (i.e. on GET `/thread/{:threadid}` and `/comment/{:commentid}`.